### PR TITLE
修改minio端口设置，改为局域网ip，便于局域网设备访问文件 此操作强制使用局域网ip+9000端口，原先application.properties中minio.endpoint已经失效，无法通过配置文件修改endpoint 要使得服务能正常运行，运行minio指令需变为minio.exe server C:\MinIO --address "0.0.0.0:9000" --console-address "localhost:9090"，将监听端口改为0.0.0.0启动对局域网设备的监听

### DIFF
--- a/src/main/java/com/work/work/config/MinioConfig.java
+++ b/src/main/java/com/work/work/config/MinioConfig.java
@@ -19,8 +19,16 @@ public class MinioConfig {
     @Bean
     public MinioClient minioClient() {
         return MinioClient.builder()
-                .endpoint(minioProperties.getEndpoint())
+                .endpoint("http://" + getLocalIp() + ":9000")
                 .credentials(minioProperties.getAccessKey(), minioProperties.getSecretKey())
                 .build();
+    }
+    private String getLocalIp() {
+        try {
+            java.net.InetAddress inetAddress = java.net.InetAddress.getLocalHost();
+            return inetAddress.getHostAddress();
+        } catch (Exception e) {
+            throw new RuntimeException("无法获取本地IP", e);
+        }
     }
 }


### PR DESCRIPTION
修改minio端口设置，改为局域网ip，便于局域网设备访问文件 此操作强制使用局域网ip+9000端口，原先application.properties中minio.endpoint已经失效，无法通过配置文件修改endpoint 要使得服务能正常运行，运行minio指令需变为minio.exe server C:\MinIO --address "0.0.0.0:9000" --console-address "localhost:9090"，将监听端口改为0.0.0.0启动对局域网设备的监听